### PR TITLE
Add browserify mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "emitter-component": "1.0.0",
     "ease-component": "1.0.0"
   },
+  "browser": {
+    "emitter": "emitter-component",
+    "ease": "ease-component"
+  },
   "license": "MIT",
   "component": {
     "scripts": {


### PR DESCRIPTION
To make able to browserify it and all dependent modules.
For now browserify don’t understand `require('emitter')`, as far there’s no `emitter` in `node_modules`, but `emitter-component`.
